### PR TITLE
Fixed arm related weirdness

### DIFF
--- a/mod/Core.cs
+++ b/mod/Core.cs
@@ -322,7 +322,7 @@ namespace ArchipelagoULTRAKILL
             GameObject obj = Instantiate(AssetHelper.LoadPrefab("Assets/Prefabs/Items/Soap.prefab"), NewMovement.Instance.transform);
             obj.transform.parent = null;
 
-            if (FistControl.Instance.currentPunch != null || !(!data.hasArm && FistControl.Instance.currentPunch.type == FistType.Standard))
+            if (FistControl.Instance.currentPunch != null)
             {
                 if (!FistControl.Instance.currentPunch.holding)
                 {
@@ -358,6 +358,30 @@ namespace ArchipelagoULTRAKILL
                 }
             }
             return list;
+        }
+
+        public static void validateArms()
+        {
+            bool resetFists = false;
+            bool unlockedArm2 = GameProgressSaver.CheckGear("arm1") == 1;
+            if (unlockedArm2 && !data.hasArm && PrefsManager.Instance.GetInt("weapon.arm0") == 1)
+            {
+                PrefsManager.Instance.SetInt("weapon.arm0", 0);
+                resetFists = true;
+            }
+            if (PrefsManager.Instance.GetInt("weapon.arm0") == 0 && PrefsManager.Instance.GetInt("weapon.arm1") == 0)
+            {
+                if (unlockedArm2)
+                {
+                    PrefsManager.Instance.SetInt("weapon.arm1", 1);
+                }
+                else
+                {
+                    PrefsManager.Instance.SetInt("weapon.arm0", 1);
+                }
+                resetFists = true;
+            }
+            if (resetFists) FistControl.Instance.ResetFists();
         }
     }
 }

--- a/mod/Patches/PlayerActivatorRelay.cs
+++ b/mod/Patches/PlayerActivatorRelay.cs
@@ -22,6 +22,10 @@ namespace ArchipelagoULTRAKILL.Patches
                     LevelManager.AddGlassComponents();
                 }
                 if ((SceneHelper.CurrentScene == "Level 1-1" || SceneHelper.CurrentScene == "Level 1-2" || SceneHelper.CurrentScene == "Level 2-3" || SceneHelper.CurrentScene == "Level 4-4" || SceneHelper.CurrentScene == "Level 5-2" || SceneHelper.CurrentScene == "Level 5-3" || SceneHelper.CurrentScene == "Level 6-1") && Core.data.randomizeSkulls) LevelManager.AddDoorClosers();
+                if (SceneHelper.CurrentScene.Contains("Level ") || SceneHelper.CurrentScene == "Endless")
+                {
+                    Core.validateArms();
+                }
                 if (Core.CurrentLevelHasInfo && Core.CurrentLevelInfo.Skulls >= SkullsType.Normal && Core.data.randomizeSkulls)
                 {
                     LevelManager.FindSkulls();

--- a/mod/Patches/ShopButton.cs
+++ b/mod/Patches/ShopButton.cs
@@ -19,8 +19,8 @@ namespace ArchipelagoULTRAKILL.Patches
                 if (__instance.variationInfo.weaponName.Contains("0")) return false;
                 if (GameProgressSaver.GetMoney() >= Core.shopPrices[__instance.variationInfo.weaponName] && !__instance.deactivated)
                 {
-                    GameProgressSaver.AddMoney(Core.shopPrices[__instance.variationInfo.weaponName] * -1);
                     LocationManager.CheckLocation("shop_" + __instance.variationInfo.weaponName);
+                    GameProgressSaver.AddMoney(Core.shopPrices[__instance.variationInfo.weaponName] * -1);
                     __instance.deactivated = true;
                     __instance.gameObject.transform.GetChild(0).GetComponent<TextMeshProUGUI>().text = "ALREADY OWNED";
                     __instance.gameObject.transform.GetChild(0).GetComponent<TextMeshProUGUI>().color = new Color(0.5882f, 0.5882f, 0.5882f);
@@ -38,7 +38,7 @@ namespace ArchipelagoULTRAKILL.Patches
         {
             if (Core.DataExists() && __instance.TryGetComponent(out ShopCategory sc))
             {
-                VariationInfo[] variations = __instance.toActivate[0].transform.Find("Variation Screen").GetComponentsInChildren<VariationInfo>(true);
+                VariationInfo[] variations = __instance.toActivate[0].transform.GetComponentsInChildren<VariationInfo>(true);
                 foreach (VariationInfo variation in variations)
                 {
                     LevelManager.UpdateShopVariation(variation);

--- a/mod/Patches/ShopZone.cs
+++ b/mod/Patches/ShopZone.cs
@@ -14,4 +14,13 @@ namespace ArchipelagoULTRAKILL.Patches
             }
         }
     }
+
+    [HarmonyPatch(typeof(ShopZone), "TurnOff")]
+    public class ShopZone_TurnOff_Patch
+    {
+        public static void Postfix()
+        {
+            if (Core.DataExists()) Core.validateArms();
+        }
+    }
 }


### PR DESCRIPTION
Added a safeguard that there is always an arm equipped, even if its the disabled feedbacker. Having no arm equipped caused a bunch of issues, like being unable to grab items/ receiving soap spawning soap every frame, etc.

Unequipping the disabled feedbacker or reenabling when owning the knuckleblaster could be done by:
- using the shop as the arm menu was bugged (fix included)
- doing so in a another (possibly vanilla) save slot

Validity of equipment is checked whenever entering levels or leaving the shop ensuring validity in all situations.