### PR TITLE
Fix 4-1 Challenge Logic

### DIFF
--- a/apworld/Rules.py
+++ b/apworld/Rules.py
@@ -514,7 +514,6 @@ class UltrakillRules:
                 or rai2(state)
                 or rock_any(state)
                 or arm1(state)
-                or revstd1_fire2(state)
                 or revalt_any(state)
                 or shostd0_fire2(state)
                 or shostd1_fire2(state)
@@ -795,7 +794,10 @@ class UltrakillRules:
             """4-1: Challenge (Don't activate any enemies)"""
             return (
                 rock0_fire2(state)
-                or slam_storage(state)
+                or (
+                    slam_storage(state)
+                    and can_break_walls(state)
+                )
                 or (
                     (
                         rai2(state)


### PR DESCRIPTION
Previously, the randomizer considered slam storage to be enough to beat the 4-1 challenge, but in order to bypass the final room, a wall needs to be broken. This PR adds the `can_break_walls` requirement to the slam storage clause on the 4-1 challenge. Additionally, the standard marksman alternate fire has been removed from the `can_break_walls` logic, as it can't on its own.

(Ignore the commit name, there was a slight kerfuffle with branches)