### PR TITLE
Fix various generation failures

### DIFF
--- a/apworld/Locations.py
+++ b/apworld/Locations.py
@@ -29,6 +29,7 @@ class UKLocation:
     game_id: str
     type: LocationType
     tracker_string: str
+    applicable_levels: set[str] | None = None
 
 
 location_list: List[UKLocation] = [
@@ -361,8 +362,10 @@ location_list: List[UKLocation] = [
     UKLocation("Boss: The Corpse of King Minos", Regions.l13, "e_minos", LocationType.Boss, "@Hell/Enemies/Boss: The Corpse of King Minos"),
     UKLocation("Enemy: Stalker", Regions.shop, "e_stalker", LocationType.Enemy, "@Hell/Enemies/Enemy: Stalker"),
     UKLocation("Enemy: Insurrectionist", Regions.shop, "e_sisyphus", LocationType.Enemy, "@Hell/Enemies/Enemy: Insurrectionist"),
-    UKLocation("Boss: Ferryman", Regions.shop, "e_ferryman", LocationType.BossExt, "@Hell/Enemies/Boss: Ferryman"),
-    UKLocation("Boss: Mirror Reaper", Regions.shop, "e_mirrorreaper", LocationType.BossExt, "@Hell/Enemies/Boss: Mirror Reaper"),
+    UKLocation("Boss: Ferryman", Regions.shop, "e_ferryman", LocationType.BossExt, "@Hell/Enemies/Boss: Ferryman",
+               applicable_levels={"5-2", "8-3", "P-2"}),
+    UKLocation("Boss: Mirror Reaper", Regions.shop, "e_mirrorreaper", LocationType.BossExt, "@Hell/Enemies/Boss: Mirror Reaper",
+               applicable_levels={"8-2"}),
     UKLocation("Enemy: Swordsmachine", Regions.shop, "e_swordsmachine", LocationType.Enemy, "@Hell/Enemies/Enemy: Swordsmachine"),
     UKLocation("Enemy: Drone", Regions.shop, "e_drone", LocationType.Enemy, "@Hell/Enemies/Enemy: Drone"),
     UKLocation("Enemy: Streetcleaner", Regions.shop, "e_streetcleaner", LocationType.Enemy, "@Hell/Enemies/Enemy: Streetcleaner"),
@@ -380,13 +383,16 @@ location_list: List[UKLocation] = [
     UKLocation("Boss: Leviathan", Regions.l23, "e_leviathan", LocationType.Boss, "@Hell/Enemies/Boss: Leviathan"),
     UKLocation("Enemy: Mannequin", Regions.shop, "e_mannequin", LocationType.Enemy, "@Hell/Enemies/Enemy: Mannequin"),
     UKLocation("Boss: Minotaur", Regions.l26, "e_minotaur", LocationType.BossExt, "@Hell/Enemies/Boss: Minotaur"),
-    UKLocation("Enemy: Deathcatcher", Regions.shop, "e_deathcatcher", LocationType.Enemy, "@Hell/Enemies/Enemy: Deathcatcher"),
+    UKLocation("Enemy: Deathcatcher", Regions.shop, "e_deathcatcher", LocationType.Enemy, "@Hell/Enemies/Enemy: Deathcatcher",
+               applicable_levels={"8-2", "8-3"}),
     UKLocation("Boss: Geryon, Watcher of the Skies", Regions.l33, "e_geryon", LocationType.Boss, "@Hell/Enemies/Boss: Geryon, Watcher of the Skies"),
     UKLocation("Boss: Gabriel, Judge of Hell", Regions.l15, "e_gabriel", LocationType.Boss, "@Hell/Enemies/Boss: Gabriel, Judge of Hell"),
     UKLocation("Enemy: Virtue", Regions.shop, "e_virtue", LocationType.Enemy, "@Hell/Enemies/Enemy: Virtue"),
     UKLocation("Boss: Gabriel, Apostate of Hate", Regions.l25, "e_gabrielsecond", LocationType.Boss, "@Hell/Enemies/Boss: Gabriel, Apostate of Hate"),
-    UKLocation("Enemy: Providence", Regions.shop, "e_providence", LocationType.Enemy, "@Hell/Enemies/Enemy: Providence"),
-    UKLocation("Enemy: Power", Regions.shop, "e_power", LocationType.Enemy, "@Hell/Enemies/Enemy: Power"),
+    UKLocation("Enemy: Providence", Regions.shop, "e_providence", LocationType.Enemy, "@Hell/Enemies/Enemy: Providence",
+               applicable_levels={"8-1", "8-2", "8-3", "8-4"}),
+    UKLocation("Enemy: Power", Regions.shop, "e_power", LocationType.Enemy, "@Hell/Enemies/Enemy: Power",
+               applicable_levels={"8-3"}),
     UKLocation("Boss: Flesh Prison", Regions.p1, "e_fleshprison", LocationType.Boss, "@Hell/Enemies/Boss: Flesh Prison"),
     UKLocation("Boss: Flesh Panopticon", Regions.p2, "e_fleshpanopticon", LocationType.Boss, "@Hell/Enemies/Boss: Flesh Panopticon"),
     UKLocation("Boss: Minos Prime", Regions.p1, "e_minosprime", LocationType.Boss, "@Hell/Enemies/Boss: Minos Prime"),

--- a/apworld/Rules.py
+++ b/apworld/Rules.py
@@ -3713,7 +3713,7 @@ class UltrakillRules:
 
             "Boss: Mirror Reaper":
                 lambda state: (
-                    can_reach_level(state, "Enemy: Mirror Reaper", "8-2")
+                    can_reach_level(state, "Boss: Mirror Reaper", "8-2")
                     and grab_item(state)
                     and skull(state, "8-2", "Blue")
                     and jump_general(state, 3)

--- a/apworld/__init__.py
+++ b/apworld/__init__.py
@@ -150,15 +150,16 @@ class UltrakillWorld(World):
         self.start_location = self.random.choice(start_weapon_locations[self.start_level.short_name])
 
         level_leads_to_secret: List[int] = [ 2, 6, 12, 17, 20, 28 ]
-        if self.options.goal_requirement.value == self.options.goal_requirement.range_end \
+        included_levels: int = self.options.goal_requirement.range_end - len(self.options.skipped_levels.value)
+
+        if self.options.goal_requirement.value >= included_levels \
             and self.options.goal_level.value in level_leads_to_secret:
                 print(f"[ULTRAKILL - '{self.player_name}'] "
-                      f"Goal requirement cannot be {self.options.goal_requirement.range_end} because goal level "
+                      f"Goal requirement cannot be {self.options.goal_requirement.value} because goal level "
                       f"{self.goal_level.short_name} leads to an inaccessible secret mission. Lowering goal "
-                      f"requirement to {self.options.goal_requirement.range_end-1}.")
-                self.options.goal_requirement.value = self.options.goal_requirement.range_end-1
+                      f"requirement to {included_levels - 1}.")
+                self.options.goal_requirement.value = included_levels - 1
 
-        included_levels: int = self.options.goal_requirement.range_end - len(self.options.skipped_levels.value)
         if self.options.goal_requirement.value > included_levels:
             raise OptionError(f"[ULTRAKILL - '{self.player_name}'] "
                             f"Goal requirement ({self.options.goal_requirement.value}) "
@@ -427,17 +428,23 @@ class UltrakillWorld(World):
 
         multiworld.regions.append(menu)
 
+        skipped = self.options.skipped_levels.value
+        enemy_types = {LocationType.Boss, LocationType.BossExt, LocationType.Enemy}
         for index, loc in enumerate(location_list):
             if loc.type in self.skipped_location_types:
                 continue
             self.game_id_to_long[loc.game_id] = (base_id + index)
-            
+
             region: Region = self.get_region(loc.region.full_name)
             location: UltrakillLocation = UltrakillLocation(player, loc.name, (base_id + index), region)
             region.locations.append(location)
 
-            if self.options.auto_exclude_skipped_locations and loc.region.short_name in self.options.skipped_levels.value:
-                self.options.exclude_locations.value.add(loc.name)
+            if loc.region.short_name in skipped:
+                if self.options.auto_exclude_skipped_locations or loc.type in enemy_types:
+                    self.options.exclude_locations.value.add(loc.name)
+            elif loc.type in enemy_types and loc.applicable_levels is not None:
+                if loc.applicable_levels.issubset(skipped):
+                    self.options.exclude_locations.value.add(loc.name)
 
         # create events for level completion
         for r in [r for r in Regions.all_regions if not (r.short_name == "shop" or r.short_name == "museum")]:


### PR DESCRIPTION
- When a level is skipped it is never reachable, but certain level specific and shop locations were still created. These would fail the AP accessibility check for full accessibility, this change makes it so these locations are only created if they are accessible.
- Fixed an incorrect location name in a rule: Enemy: Mirror Reaper -> Boss: Mirror Reaper
- Secret missions of goal levels were being counted towards access to those levels, making access impossible

This was tested by running the [fuzzer](https://github.com/Eijebong/Archipelago-fuzzer) 1000 times with [empty.apworld](https://github.com/Eijebong/empty-apworld) as a static world. There were no failures.